### PR TITLE
Change to function name

### DIFF
--- a/demo/main.c
+++ b/demo/main.c
@@ -15,7 +15,7 @@ int main()
 		return 1;
 	}
 	flitdb *flit;
-	if (flitdb_setup("demo.db", &flit, FLITDB_CREATE) != FLITDB_SUCCESS)
+	if (flitdb_open("demo.db", &flit, FLITDB_CREATE) != FLITDB_SUCCESS)
 	{
 		printf("%s\n", flitdb_errmsg(&flit));
 		return 1;

--- a/flitdb/flit.c
+++ b/flitdb/flit.c
@@ -77,7 +77,7 @@ unsigned int flitdb_version_check()
 	return FLITDB_VERSION;
 }
 
-int flitdb_setup(const char *filename, flitdb **handler, int flags)
+int flitdb_open(const char *filename, flitdb **handler, int flags)
 {
 	if (flitdb_new(handler) == FLITDB_ERROR)
 	{

--- a/flitdb/flit.h
+++ b/flitdb/flit.h
@@ -2,28 +2,28 @@
 #define flit_h
 #include <stdbool.h>
 
-#define FLITDB_SUCCESS      0  // Successful operation
-#define FLITDB_ERROR        1  // Unsuccessful operation
-#define FLITDB_PERM         2  // Permission denied
-#define FLITDB_BUSY         3  // The database file is locked
-#define FLITDB_NOT_FOUND    4  // The database file is not found
-#define FLITDB_CORRUPT      5  // The database file is malformed
-#define FLITDB_RANGE        6  // The requested range is outside the range of the database
-#define FLITDB_CREATE       7  // Create a database if not existent
-#define FLITDB_READONLY     8  // Only allow the reading of the database
-#define FLITDB_DONE         9  // The operation was completed successfully
-#define FLITDB_NULL         10 // The operation resulted in a null lookup
-#define FLITDB_INTEGER      11 // The value type of int
-#define FLITDB_FLOAT        12 // The value type of float
-#define FLITDB_CHAR         13 // The value type of char
-#define FLITDB_BOOL         14 // The value type of bool
-#define FLITDB_UNSAFE       16 // Discard all safety protocols to allow for larger database
-#define FLITDB_VERSION  0xefc7 // The current FlitDB version magic number
+#define FLITDB_SUCCESS       0  // Successful operation
+#define FLITDB_ERROR         1  // Unsuccessful operation
+#define FLITDB_PERM          2  // Permission denied
+#define FLITDB_BUSY          3  // The database file is locked
+#define FLITDB_NOT_FOUND     4  // The database file is not found
+#define FLITDB_CORRUPT       5  // The database file is malformed
+#define FLITDB_RANGE         6  // The requested range is outside the range of the database
+#define FLITDB_CREATE        7  // Create a database if not existent
+#define FLITDB_READONLY      8  // Only allow the reading of the database
+#define FLITDB_DONE          9  // The operation was completed successfully
+#define FLITDB_NULL          10 // The operation resulted in a null lookup
+#define FLITDB_INTEGER       11 // The value type of int
+#define FLITDB_FLOAT         12 // The value type of float
+#define FLITDB_CHAR          13 // The value type of char
+#define FLITDB_BOOL          14 // The value type of bool
+#define FLITDB_UNSAFE        16 // Discard all safety protocols to allow for larger database
+#define FLITDB_VERSION  0x117ee // The current FlitDB version magic number
 
 // Database sizing options
 #define FLITDB_SIZING_MODE_TINY  1 // Handle databases up to 14.74 megabytes in size
 #define FLITDB_SIZING_MODE_SMALL 2 // Handle databases up to 4.26 gigabytes in size
-#define FLITDB_SIZING_MODE_BIG   3 // Handle databases up to 281.470 terabytes in size
+#define FLITDB_SIZING_MODE_BIG   3 // Handle databases up to 281.47 terabytes in size
 
 // Database memory mapping
 #define FLITDB_MMAP_ALLOWED 1 // Allows the database to memory map files - if possible (1 - allowed, 0 - dissallowed)
@@ -52,7 +52,7 @@ typedef unsigned short flitdb_column_row_sizing;
  * @param flags The read write operation flags to set on the database file
  * @return int 
  */
-flitdb_extern int flitdb_setup(const char *filename, flitdb **handler, int flags);
+flitdb_extern int flitdb_open(const char *filename, flitdb **handler, int flags);
 
 /**
  * @brief Close the connection to the database, and delete the FlitDB handler object

--- a/tests/alterations.c
+++ b/tests/alterations.c
@@ -11,7 +11,7 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
 	typedef struct value
 	{
 		unsigned short column;

--- a/tests/deletions.c
+++ b/tests/deletions.c
@@ -10,7 +10,7 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
 	bool (*deleted)[MAX];
 	deleted = malloc((MAX + 1) * (MAX + 1) * sizeof deleted[0][0]);
 	int deleted_amount = 0;

--- a/tests/inserts.c
+++ b/tests/inserts.c
@@ -11,7 +11,7 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
 	int (*inserted)[MAX];
 	inserted = malloc((MAX + 1) * (MAX + 1) * sizeof inserted[0][0]);
 	int inserted_amount = 0;

--- a/tests/inverse_sequential_deletions.c
+++ b/tests/inverse_sequential_deletions.c
@@ -11,7 +11,7 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test2.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test2.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
 	for (unsigned short x = MAX; ; --x)
 	{
 		for (unsigned short y = MAX; ; --y)

--- a/tests/inverse_sequential_inserts.c
+++ b/tests/inverse_sequential_inserts.c
@@ -11,7 +11,7 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test2.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test2.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
 	int (*inserted)[MAX];
 	inserted = malloc((MAX + 1) * (MAX + 1) * sizeof inserted[0][0]);
 	for (unsigned short x = MAX; x > 0; x--)

--- a/tests/permission_create.c
+++ b/tests/permission_create.c
@@ -7,9 +7,9 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test_create.db", &flit, FLITDB_READONLY) == FLITDB_NOT_FOUND);
+	assert(flitdb_open("./test_create.db", &flit, FLITDB_READONLY) == FLITDB_NOT_FOUND);
 	flitdb_close(&flit);
-	assert(flitdb_setup("./test_create.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test_create.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
 	flitdb_close(&flit);
 	return 0;
 }

--- a/tests/permission_readonly.c
+++ b/tests/permission_readonly.c
@@ -7,12 +7,12 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test_readonly.db", &flit, FLITDB_READONLY) == FLITDB_NOT_FOUND);
+	assert(flitdb_open("./test_readonly.db", &flit, FLITDB_READONLY) == FLITDB_NOT_FOUND);
 	flitdb_close(&flit);
 	FILE *readonly_db;
 	readonly_db = fopen("./test_readonly.db", "w"); // create empty database
 	fclose(readonly_db);
-	assert(flitdb_setup("./test_readonly.db", &flit, FLITDB_READONLY) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test_readonly.db", &flit, FLITDB_READONLY) == FLITDB_SUCCESS);
 	assert(flitdb_insert_int(&flit, 1, 1, 12345) == FLITDB_READONLY);
 	flitdb_close(&flit);
 	return 0;

--- a/tests/sequential_deletions.c
+++ b/tests/sequential_deletions.c
@@ -10,7 +10,7 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test2.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test2.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
 	for (unsigned short x = 0; x < MAX; x++)
 	{
 		for (unsigned short y = 0; y < MAX; y++)

--- a/tests/sequential_inserts.c
+++ b/tests/sequential_inserts.c
@@ -11,7 +11,7 @@
 int main(int argc, char const *argv[])
 {
 	flitdb *flit;
-	assert(flitdb_setup("./test2.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_open("./test2.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
 	int (*inserted)[MAX];
 	inserted = malloc((MAX + 1) * (MAX + 1) * sizeof inserted[0][0]);
 	for (unsigned short x = 0; x < MAX; x++)


### PR DESCRIPTION
Changed the name of the function `flitdb_setup` to `flitdb_open` to better reflect what the function does behind the API wrapper. This would also result in an easier understanding of the function - for people whom are viewing the API for the first time.