### PR TITLE
Improved commenting, memory management and testing

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -24,5 +24,5 @@ jobs:
         CC: ${{ matrix.compiler }}
       working-directory: ${{env.working-directory}}
     - name: make test
-      run: make test_silent
+      run: make test_
       working-directory: ${{env.working-directory}}

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,7 +1,6 @@
-GCC=gcc
+CC ?= gcc
 SRCDIR=../flitdb
 ARGS=-Wall -g -ggdb
-LIB_ARGS=-DFLITDB_LIB_DEMO
 LIB_LINK=-lflitdb
 BUILD_DIR=./build
 TARGET=demo
@@ -23,15 +22,15 @@ setup_lib:
 
 build:
 	@echo -n "Compiling... "
-	@$(GCC) $(ARGS) -c $(SRC)
-	@$(GCC) -o $(BUILD_DIR)/$(TARGET) $(OBJ)
+	@$(CC) $(ARGS) -c $(SRC)
+	@$(CC) -o $(BUILD_DIR)/$(TARGET) $(OBJ)
 	@echo "Done"
 
 build_lib:
 	@cd $(SRCDIR) && $(MAKE)
 	@echo -n "Compiling with shared library... "
-	@$(GCC) $(ARGS) $(LIB_ARGS) -c $(DEMO_FILES)
-	@$(GCC) $(ARGS) $(DEMO_FILES:.c=.o) $(LIB_LINK) -o $(BUILD_DIR)/$(TARGET)
+	@$(CC) $(ARGS) -c $(DEMO_FILES)
+	@$(CC) $(ARGS) $(DEMO_FILES:.c=.o) $(LIB_LINK) -o $(BUILD_DIR)/$(TARGET)
 	@echo "Done"
 
 lib: setup_lib build_lib

--- a/flitdb/Makefile
+++ b/flitdb/Makefile
@@ -1,4 +1,4 @@
-GCC=gcc
+CC ?= gcc
 LIB=libflitdb.so
 LIB_PATH=/usr/lib
 HEADER_PATH=/usr/include/flit.h
@@ -16,10 +16,10 @@ default: build update clean done
 
 build:
 	@echo -n "Generating object..."
-	@$(GCC) $(OBJ_ARGS) -c $(SRC)
+	@$(CC) $(OBJ_ARGS) -c $(SRC)
 	@echo " done"
 	@echo -n "Generating shared library..."
-	@$(GCC) -fPIC -s -shared -o $(LIB) $(OBJ)
+	@$(CC) -fPIC -s -shared -o $(LIB) $(OBJ)
 	@echo " done"
 
 update:

--- a/flitdb/Makefile
+++ b/flitdb/Makefile
@@ -3,7 +3,6 @@ LIB=libflitdb.so
 LIB_PATH=/usr/lib
 HEADER_PATH=/usr/include/flit.h
 OBJ_ARGS=-fPIC -Os -Wno-format-truncation
-LIB_OBJ_ARG=
 ifeq ($(shell uname -s),Darwin)
 	LIB=libflitdb.dylib
 	LIB_PATH=/usr/local/lib

--- a/flitdb/flit.c
+++ b/flitdb/flit.c
@@ -623,7 +623,6 @@ unsigned char flitdb_read_at(flitdb **handler, flitdb_column_row_sizing column_p
 	void *mmapped_file = (void *)-1;
 	if ((*handler)->read_only)
 		mmapped_file = mmap(NULL, (*handler)->size, PROT_READ, MAP_PRIVATE, fileno((*handler)->file_descriptor), 0); // Attempt to allocate memory to map to file
-	printf("MMAP!\n");
 #endif
 	for (;;)
 	{

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,6 +31,13 @@ build:
 	$(CC) $(ARGS) alterations.o flit.o -o $(BUILD_DIR)/test_alterations
 	$(CC) $(ARGS) permission_create.o flit.o -o $(BUILD_DIR)/test_permission_create
 	$(CC) $(ARGS) permission_readonly.o flit.o -o $(BUILD_DIR)/test_permission_readonly
+	sed "s/#define FLITDB_SIZING_MODE FLITDB_SIZING_MODE_BIG/#define FLITDB_SIZING_MODE FLITDB_SIZING_MODE_TINY/g" flit.h > flit2.h && mv flit2.h flit.h
+	rm flit.o
+	$(CC) $(ARGS) -c flit.c
+	$(CC) $(ARGS) -c mmap.c
+	$(CC) $(ARGS) -c range.c
+	$(CC) $(ARGS) mmap.o flit.o -o $(BUILD_DIR)/test_mmap
+	$(CC) $(ARGS) range.o flit.o -o $(BUILD_DIR)/test_range
 
 test:
 	@mkdir -pv $(BUILD_DIR)
@@ -49,6 +56,8 @@ test:
 	@cd $(BUILD_DIR);./test_inverse_sequential_delete > /dev/null 2>&1 && echo "~ Success" || echo "~ Failed"
 	@echo -n "Alternating values           "
 	@cd $(BUILD_DIR);./test_alterations > /dev/null 2>&1 && echo "~ Success" || echo "~ Failed"
+	@echo -n "Memory mapped reading        "
+	@cd $(BUILD_DIR);./test_mmap > /dev/null 2>&1 && echo "~ Success" || echo "~ Failed"
 	@echo -n "Permission create            "
 	@cd $(BUILD_DIR);./test_permission_create > /dev/null 2>&1 && echo "~ Success" || echo "~ Failed"
 	@echo -n "Permission readonly          "

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -71,6 +71,8 @@ test_silent:
 	@cd $(BUILD_DIR);./test_sequential_delete
 	@cd $(BUILD_DIR);./test_inverse_sequential_inserts
 	@cd $(BUILD_DIR);./test_inverse_sequential_delete
+	@cd $(BUILD_DIR);./test_alterations
+	@cd $(BUILD_DIR);./test_mmap
 	@cd $(BUILD_DIR);./test_permission_create
 	@cd $(BUILD_DIR);./test_permission_readonly
 clean:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-CC = g++
+CC ?= gcc
 BUILD_DIR=./build
 ARGS=-Wall -g -ggdb
 SRCDIR=../flitdb

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-CC ?= gcc
+CC = g++
 BUILD_DIR=./build
 ARGS=-Wall -g -ggdb
 SRCDIR=../flitdb
@@ -63,17 +63,17 @@ test:
 	@echo -n "Permission readonly          "
 	@cd $(BUILD_DIR);./test_permission_readonly > /dev/null 2>&1 && echo "~ Success" || echo "~ Failed"
 
-test_silent:
+test_:
 	@mkdir -pv $(BUILD_DIR)
-	@cd $(BUILD_DIR);./test_insert
-	@cd $(BUILD_DIR);./test_delete
-	@cd $(BUILD_DIR);./test_sequential_inserts
-	@cd $(BUILD_DIR);./test_sequential_delete
-	@cd $(BUILD_DIR);./test_inverse_sequential_inserts
-	@cd $(BUILD_DIR);./test_inverse_sequential_delete
-	@cd $(BUILD_DIR);./test_alterations
-	@cd $(BUILD_DIR);./test_mmap
-	@cd $(BUILD_DIR);./test_permission_create
-	@cd $(BUILD_DIR);./test_permission_readonly
+	cd $(BUILD_DIR);./test_insert
+	cd $(BUILD_DIR);./test_delete
+	cd $(BUILD_DIR);./test_sequential_inserts
+	cd $(BUILD_DIR);./test_sequential_delete
+	cd $(BUILD_DIR);./test_inverse_sequential_inserts
+	cd $(BUILD_DIR);./test_inverse_sequential_delete
+	cd $(BUILD_DIR);./test_alterations
+	cd $(BUILD_DIR);./test_mmap
+	cd $(BUILD_DIR);./test_permission_create
+	cd $(BUILD_DIR);./test_permission_readonly
 clean:
 	@rm -rfv $(BUILD_DIR) *.o flit.*

--- a/tests/alterations.c
+++ b/tests/alterations.c
@@ -35,7 +35,7 @@ int main(int argc, char const *argv[])
 			for (unsigned int y = 0; y < MAX; y++)
 			{
 				checkpoint_counter++;
-				data_type += 1;
+				data_type += (rand() % 4);
 				data_type %= 5;
 				union value
 				{
@@ -50,7 +50,7 @@ int main(int argc, char const *argv[])
 					assert(flitdb_insert_int(&flit, (x + 1), (y + 1), value.integer_value) == FLITDB_DONE);
 					break;
 				case 1:
-					value.float_value = ((float)rand()/(float)(rand() / MAX_VALUE));
+					value.float_value = ((float)rand() / (float)(rand() / MAX_VALUE));
 					assert(flitdb_insert_float(&flit, (x + 1), (y + 1), value.float_value) == FLITDB_DONE);
 					break;
 				case 2:
@@ -122,6 +122,105 @@ int main(int argc, char const *argv[])
 					}
 				}
 			}
+		}
+	}
+	checkpoints[0].result.integer_value = 12345;
+	checkpoints[1].result.integer_value = 54321;
+	assert(flitdb_insert_int(&flit, 1, 100, checkpoints[0].result.integer_value) == FLITDB_DONE);
+	assert(flitdb_insert_int(&flit, 2, 2, checkpoints[1].result.integer_value) == FLITDB_DONE);
+	checkpoints[0].column = 1;
+	checkpoints[0].row = 100;
+	checkpoints[0].type = 0;
+	checkpoints[1].column = 2;
+	checkpoints[1].row = 2;
+	checkpoints[1].type = 0;
+	int int_validation = 12345;
+	float float_validation = 123.456;
+	char *char_validation = "test";
+	bool bool_validation = true;
+	for (unsigned char i = 0; i < 5; i++)
+	{
+		for (unsigned char ii = 0; ii < 5; ii++)
+		{
+			printf(" i. %i\nii. %d\n", i, ii);
+			switch (i)
+			{
+			case 0:
+			{
+				assert(flitdb_insert_int(&flit, 2, 1, int_validation) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_DONE);
+				assert(flitdb_retrieve_int(&flit) == int_validation);
+				break;
+			}
+			case 1:
+			{
+				assert(flitdb_insert_float(&flit, 2, 1, float_validation) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_DONE);
+				assert(flitdb_retrieve_float(&flit) == float_validation);
+				break;
+			}
+			case 2:
+			{
+				assert(flitdb_insert_char(&flit, 2, 1, char_validation) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_DONE);
+				assert(strcmp(flitdb_retrieve_char(&flit), char_validation) == 0);
+				break;
+			}
+			case 3:
+			{
+				assert(flitdb_insert_bool(&flit, 2, 1, bool_validation) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_DONE);
+				assert(flitdb_retrieve_bool(&flit) == bool_validation);
+				break;
+			}
+			case 4:
+			{
+				assert(flitdb_delete(&flit, 2, 1) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_NULL);
+				break;
+			}
+			}
+			switch (ii)
+			{
+			case 0:
+			{
+				assert(flitdb_insert_int(&flit, 2, 1, int_validation) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_DONE);
+				assert(flitdb_retrieve_int(&flit) == int_validation);
+				break;
+			}
+			case 1:
+			{
+				assert(flitdb_insert_float(&flit, 2, 1, float_validation) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_DONE);
+				assert(flitdb_retrieve_float(&flit) == float_validation);
+				break;
+			}
+			case 2:
+			{
+				assert(flitdb_insert_char(&flit, 2, 1, char_validation) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_DONE);
+				assert(strcmp(flitdb_retrieve_char(&flit), char_validation) == 0);
+				break;
+			}
+			case 3:
+			{
+				assert(flitdb_insert_bool(&flit, 2, 1, bool_validation) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_DONE);
+				assert(flitdb_retrieve_bool(&flit) == bool_validation);
+				break;
+			}
+			case 4:
+			{
+				assert(flitdb_delete(&flit, 2, 1) == FLITDB_DONE);
+				assert(flitdb_extract(&flit, 2, 1) == FLITDB_NULL);
+				break;
+			}
+			}
+			assert(flitdb_extract(&flit, checkpoints[0].column, checkpoints[0].row) == FLITDB_DONE);
+			assert(flitdb_retrieve_int(&flit) == checkpoints[0].result.integer_value);
+			assert(flitdb_extract(&flit, checkpoints[1].column, checkpoints[1].row) == FLITDB_DONE);
+			assert(flitdb_retrieve_int(&flit) == checkpoints[1].result.integer_value);
 		}
 	}
 	flitdb_close(&flit);

--- a/tests/alterations.c
+++ b/tests/alterations.c
@@ -142,7 +142,6 @@ int main(int argc, char const *argv[])
 	{
 		for (unsigned char ii = 0; ii < 5; ii++)
 		{
-			printf(" i. %i\nii. %d\n", i, ii);
 			switch (i)
 			{
 			case 0:

--- a/tests/mmap.c
+++ b/tests/mmap.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <assert.h>
+#include "flit.h"
+
+int main(int argc, char const *argv[])
+{
+	flitdb *flit;
+	assert(flitdb_open("./test_mmap.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	for (unsigned char i = 1; i <= 0x10; i++)
+		for (unsigned char ii = 1; ii <= 0x10; ii++)
+			assert(flitdb_insert_int(&flit, i, ii, 12345) == FLITDB_DONE);
+	flitdb_close(&flit);
+	assert(flitdb_open("./test_mmap.db", &flit, FLITDB_READONLY) == FLITDB_SUCCESS);
+	for (unsigned char i = 1; i <= 0x10; i++)
+		for (unsigned char ii = 1; ii <= 0x10; ii++)
+		{
+			assert(flitdb_extract(&flit, i, ii) == FLITDB_DONE);
+			assert(flitdb_retrieve_int(&flit) == 12345);
+		}
+	flitdb_close(&flit);
+	return 0;
+}

--- a/tests/range.c
+++ b/tests/range.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <assert.h>
+#include "flit.h"
+
+int main(int argc, char const *argv[])
+{
+	flitdb *flit;
+	assert(flitdb_open("./test_exceed.db", &flit, FLITDB_CREATE) == FLITDB_SUCCESS);
+	assert(flitdb_insert_int(&flit, 17, 1, 1) == FLITDB_RANGE);
+	assert(flitdb_insert_int(&flit, 1, 17, 1) == FLITDB_RANGE);
+	assert(flitdb_insert_int(&flit, 1, 0, 1) == FLITDB_RANGE);
+	assert(flitdb_insert_int(&flit, 0, 1, 1) == FLITDB_RANGE);
+	flitdb_close(&flit);
+	return 0;
+}


### PR DESCRIPTION
Improved commenting throughout `flit.c`, as well as removed unnecessary memory allocations. Also, additional changes were made to each `Makefile`, to make the layouts of each - consistent. Added - and improved - tests, to have a complete testing suite, with additional changes to the compilation, by adjusting the `FLITDB_SIZING_MODE` compilation variable for certain tests.